### PR TITLE
Fixes paths layout

### DIFF
--- a/components/Home/Paths.tsx
+++ b/components/Home/Paths.tsx
@@ -2,15 +2,15 @@
 
 const Paths: React.FC = () => {
   return (
-    <section className="flex flex-col items-center justify-start py-32 darkmode-section">
+    <section className="flex flex-col justify-start py-32 darkmode-section">
       <div className="flex flex-row self-start ">
         <div className="w-24 h-6 ml-4 bg-blue-500 rounded-full rounded-s-none"></div>
         <div className="w-6 h-6 ml-4 bg-blue-500 rounded-full"></div>
         <h4>המסלולים שלנו</h4>
       </div>
-      <div className="flex flex-col gap-1 mx-6 mt-6 lg:mt-0 lg:flex-row lg:mx-16 lg:gap-4 xl:gap-8">
-        {PATHS.map((path, i) => (
-          <Path key={path.title} item={path} index={i} />
+      <div className="flex flex-row grow flex-wrap gap-y-4 mt-6 lg:mt-0 lg:flex-row py-4 lg:py-32 justify-evenly">
+        {PATHS.map(path => (
+          <Path key={path.title} item={path} />
         ))}
       </div>
     </section>
@@ -24,23 +24,18 @@ interface PathProps {
     description: string;
     link: { name: string; href: string };
   };
-  index: number;
 }
 
-const Path = ({ item, index }: PathProps) => {
+const Path = ({ item }: PathProps) => {
   return (
-    <article className="flex flex-row items-center justify-center py-4 lg:py-32">
-      <div className="flex flex-col items-center gap-4">
-        <div className="w-6 h-6 ml-4 bg-blue-300 rounded-full dark:bg-gray-700"></div>
-        <div
-          className={`h-36 w-4 rounded-full bg-blue-300 dark:bg-gray-700 ml-4 ${
-            index % 2 === 1 && 'h-48'
-          }`}
-        ></div>
-      </div>
-      <div className="flex flex-col w-1/2 gap-6">
-        <h4 className="capitalize">{item.title}</h4>
-        <p className="w-5/6 body-roman">{item.description}</p>
+    <article className="grid grid-cols-[min-content_1fr] grid-rows-[min-content_1fr]  w-72 gap-y-1.5 gap-x-3">
+      <div className="w-6 h-6 bg-blue-300 rounded-full dark:bg-gray-700 self-center"></div>
+      <div
+        className={`w-4 rounded-full bg-blue-300 dark:bg-gray-700 flex-grow col row-start-2 row-end-2 justify-self-center`}
+      ></div>
+      <h4 className="capitalize self-center">{item.title}</h4>
+      <div className="flex flex-col grow justify-between gap-2 min-h-[128px]">
+        <p className="body-roman">{item.description}</p>
         <a
           className="px-4 py-2 body-bold bg-lightText dark:bg-gray-700 w-fit rounded-xl"
           href={item.link.href}


### PR DESCRIPTION
Aligns Paths to be on the same line
Grids a path's vertical bar and content to the same length
Moves padding from Path to its container Paths

Fixes #43

Paths after pr
![i51G4ccuna](https://github.com/Maakaf/maakaf-website/assets/90090260/02e22c03-dc7f-4cf9-a97e-08f7cbeccd0a)

 Paths before pr
![paths before pr](https://github.com/Maakaf/maakaf-website/assets/90090260/d1f2e8e2-bf4f-43c3-85de-4dba94421e38)
