### PR TITLE
Improve single project card

### DIFF
--- a/components/Common/DiscordLink.tsx
+++ b/components/Common/DiscordLink.tsx
@@ -22,7 +22,7 @@ export default function DiscordLink({
       )}
     >
       {children}
-      {/* <Image src={'/images/discord.png'} alt="discord" width={20} height={20} /> */}
+      <Image src={'/images/discord.png'} alt="discord" width={20} height={20} />
     </Link>
   );
 }

--- a/components/Projects/ProjectCard/ProjectCard.tsx
+++ b/components/Projects/ProjectCard/ProjectCard.tsx
@@ -7,6 +7,7 @@ import AvatarList from './AvatarList';
 import { AvatarData } from './Avatar';
 import DiscordLink from '@/components/Common/DiscordLink';
 import { RepoItem } from '@/hooks/useFetchProjects';
+import { LINKS } from '@/config/consts';
 
 export interface ProjectCardProps {
   project: RepoItem;
@@ -24,6 +25,7 @@ export default function ProjectCard({
     contributors: { edges: contributors },
   },
 }: ProjectCardProps) {
+
   const updatedDateString = new Date(updatedAt)
     .toLocaleDateString('he-IL')
     .replaceAll('.', '/');
@@ -80,13 +82,13 @@ export default function ProjectCard({
             tags={languages.edges.map(l => l.node.name)}
           ></TagList>
           <div className="flex gap-2">
-            {/* <GithubButton link={LINKS.GITHUB_LINK} />
+            <GithubButton link={LINKS.MAAKAF_GITHUB} />
             <DiscordLink
-              href={LINKS.DISCORD_LINK}
+              href={LINKS.DISCORD}
               className="flex-grow-[2] font-inter font-semibold bg-gray-50 text-gray-600 py-2 px-6"
             >
               ערוץ דיסקורד
-            </DiscordLink> */}
+            </DiscordLink>
           </div>
         </div>
       </div>

--- a/components/Projects/ProjectCard/ProjectCard.tsx
+++ b/components/Projects/ProjectCard/ProjectCard.tsx
@@ -4,7 +4,6 @@ import ProjectImagePlaceholder from './ProjectImagePlaceholder.png';
 import ImageWithFallback from '@/components/utils/ImageWithFallback';
 import TagList from './TagList';
 import AvatarList from './AvatarList';
-import { AvatarData } from './Avatar';
 import DiscordLink from '@/components/Common/DiscordLink';
 import { RepoItem } from '@/hooks/useFetchProjects';
 import { LINKS } from '@/config/consts';
@@ -81,7 +80,7 @@ export default function ProjectCard({
             className="flex-wrap grow basis-[min-content]"
             tags={languages.edges.map(l => l.node.name)}
           ></TagList>
-          <div className="flex gap-2">
+          <div className="flex gap-2">  
             <GithubButton link={url || LINKS.MAAKAF_GITHUB} />
             <DiscordLink
               href={LINKS.DISCORD}

--- a/components/Projects/ProjectCard/ProjectCard.tsx
+++ b/components/Projects/ProjectCard/ProjectCard.tsx
@@ -19,7 +19,7 @@ export default function ProjectCard({
     updatedAt,
     createdAt,
     name,
-    collaborators,
+    url,
     description,
     languages,
     contributors: { edges: contributors },
@@ -62,7 +62,7 @@ export default function ProjectCard({
             <div className="font-birzia text-xl font-bold">{name}</div>
             <div className="flex grow sm:justify-between items-center gap-2">
               <div className="font-inter text-xs text-lightText bg-blue-400 dark:bg-pink-500 rounded-[50px] px-6 py-2 font-semibold">
-                {collaborators?.totalCount || 0} תורמים
+                {contributors.length || 0} תורמים
               </div>
               <AvatarList
                 avatars={contributors.map(c => ({
@@ -82,7 +82,7 @@ export default function ProjectCard({
             tags={languages.edges.map(l => l.node.name)}
           ></TagList>
           <div className="flex gap-2">
-            <GithubButton link={LINKS.MAAKAF_GITHUB} />
+            <GithubButton link={url || LINKS.MAAKAF_GITHUB} />
             <DiscordLink
               href={LINKS.DISCORD}
               className="flex-grow-[2] font-inter font-semibold bg-gray-50 text-gray-600 py-2 px-6"

--- a/config/consts.ts
+++ b/config/consts.ts
@@ -2,6 +2,7 @@ export const LINKS = {
   NEWBIES: '/newbies',
   COMMUNITY_MEMBERS: '/members',
   CONTRIBUTORS: 'https://github.com/Maakaf/maakaf-website/graphs/contributors',
+  MAAKAF_GITHUB: 'https://github.com/Maakaf/maakaf-website',
   COMMUNITY_MAINTAINERS: '/maintainers',
   PROJECTS: '/projects',
   CONTACT_US: '/not-found',


### PR DESCRIPTION
Fix #170 

Added a GitHub repo link button and a Discord link button. Currently, the Discord link redirects to Maakaf's Discord server. Would you happen to know if it's possible to redirect it to a specific channel?

Now, we display the total number of contributors.

![image](https://github.com/Maakaf/maakaf-website/assets/34707669/ed9d2f89-e1d2-47b9-9537-15d128cf7a46)
![image](https://github.com/Maakaf/maakaf-website/assets/34707669/e5b64bdc-3b81-433f-a260-0a30497ab57e)


Btw, I was thinking of adding a button next to the contributors that will display the total number of stars. What do you think?"

