### PR TITLE
Redirect project card discord button

### DIFF
--- a/components/Projects/ProjectCard/ProjectCard.tsx
+++ b/components/Projects/ProjectCard/ProjectCard.tsx
@@ -1,6 +1,5 @@
 import ProjectCardDescription from './ProjectCardDescription';
 import ProjectImagePlaceholder from './ProjectImagePlaceholder.png';
-import ImageWithFalllaceholder from './ProjectImagePlaceholder.png';
 import ImageWithFallback from '@/components/utils/ImageWithFallback';
 import TagList from './TagList';
 import AvatarList from './AvatarList';
@@ -8,6 +7,8 @@ import DiscordLink from '@/components/Common/DiscordLink';
 import { LINKS } from '@/config/consts';
 import { RepoItem } from '@/types';
 import GithubButton from './GithubButton';
+import { getChannelUrl } from '../linkToDiscordChannel';
+
 
 export interface ProjectCardProps {
   project: RepoItem;
@@ -83,7 +84,7 @@ export default function ProjectCard({
           <div className="flex gap-2">
             <GithubButton link={url || LINKS.MAAKAF_GITHUB} />
             <DiscordLink
-              href={"https://discord.com/channels/1089589164707684443/1163081100034326570"}
+              href={getChannelUrl(name)}
               className="flex-grow-[2] font-inter font-semibold bg-gray-50 text-gray-600 py-2 px-6"
             >
               ערוץ דיסקורד

--- a/components/Projects/ProjectCard/ProjectCard.tsx
+++ b/components/Projects/ProjectCard/ProjectCard.tsx
@@ -82,7 +82,7 @@ export default function ProjectCard({
           <div className="flex gap-2">
             <GithubButton link={url || LINKS.MAAKAF_GITHUB} />
             <DiscordLink
-              href={LINKS.DISCORD}
+              href={"https://discord.com/channels/1089589164707684443/1163081100034326570"}
               className="flex-grow-[2] font-inter font-semibold bg-gray-50 text-gray-600 py-2 px-6"
             >
               ערוץ דיסקורד

--- a/components/Projects/linkToDiscordChannel.ts
+++ b/components/Projects/linkToDiscordChannel.ts
@@ -1,6 +1,6 @@
 const MAAKAF_SERVER_ID = "1089589164707684443"
 
-const projectsChannelsId : { [key: string]: string } = {
+const PROJECT_CHANNELS_IDS : { [key: string]: string } = {
  "url-title-preview": "1216300095931158558",
  "progit2" : "1216603861071040572",
  "MAAKAF_MeOnTheLine" : "1215351169225064448",
@@ -28,6 +28,6 @@ const projectsChannelsId : { [key: string]: string } = {
 }
 
 export const getChannelUrl = (projectName : string) => {
-    let projectDiscordChannel  = projectsChannelsId[projectName] || "";
+    let projectDiscordChannel  = PROJECT_CHANNELS_IDS[projectName] || "";
     return `https://discord.com/channels/${MAAKAF_SERVER_ID}/${projectDiscordChannel}`
 }

--- a/components/Projects/linkToDiscordChannel.ts
+++ b/components/Projects/linkToDiscordChannel.ts
@@ -1,8 +1,33 @@
-const projectsChannelsId = {
-    
+const MAAKAF_SERVER_ID = "1089589164707684443"
 
+const projectsChannelsId : { [key: string]: string } = {
+ "url-title-preview": "1216300095931158558",
+ "progit2" : "1216603861071040572",
+ "MAAKAF_MeOnTheLine" : "1215351169225064448",
+ "cboard":"1213401866961162291",
+ "lite-fifo": "1212668320273408041",
+ "caspion": "1137747025081946312",
+ "overlay" : "1101157903093747833",
+ "2ms": "1118614587609198735",
+ "configu": "1191310798518243438",
+ "emojiPicker": "1111604241048535042",
+ "mappingthestudio64bit": "1170314519348785152",
+ "keep": "1188512417181863956",
+ "Kef-Code" : "1156691589922562058",
+ "redberry-crm" : "1196012132513366026",
+ "github-readme-youtube-cards" : "1150648666781139044",
+ "github-readme-streak-stats" : "1150648983098769418",
+ "readme-typing-svg" : "1150649218717995078",
+ "mapping-rs" : "1144877273091149875",
+ "cocmd" : "1168156294469926942",
+ "emoji-picker-react" : "1111604241048535042",
+ "reduced.to" : "1101859074359955517",
+ "open-bus-map-search" : "1150649893799608401",
+ "open-bus-stride-api" : "1150650094140522619",
+ "kor" : "1141416526784757813"
 }
 
 export const getChannelUrl = (projectName : string) => {
-
+    let projectDiscordChannel  = projectsChannelsId[projectName] || "";
+    return `https://discord.com/channels/${MAAKAF_SERVER_ID}/${projectDiscordChannel}`
 }

--- a/components/Projects/linkToDiscordChannel.ts
+++ b/components/Projects/linkToDiscordChannel.ts
@@ -1,0 +1,8 @@
+const projectsChannelsId = {
+    
+
+}
+
+export const getChannelUrl = (projectName : string) => {
+
+}


### PR DESCRIPTION
Now when you click here (projects page) : 

![image](https://github.com/Maakaf/maakaf-website/assets/34707669/59696054-656c-46de-9ca8-7c951465e67b)

You will get redirected to the relevant discord channel if it exists or to the server itself if the server does not exist.

Fix #182 