### PR TITLE
Solve "Warning: Extra attributes from the server: class" error

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,9 +7,5 @@ export default function RootLayout({
   children: React.ReactNode;
   params: { locale: string };
 }) {
-  return (
-    <html lang={locale} dir="rtl">
-      <body>{children}</body>
-    </html>
-  );
+  return <html suppressHydrationWarning={true}>{children}</html>;
 }


### PR DESCRIPTION
- Suppress theme's hydration warning in the root <html>
- Remove root body

Gotta remove one <body> since Nextjs doesn't like it when there's more than one <body> and will error if there's any props on any of the bodies
Gotta be the root <body>, cause the locale <html> must have a <body> as a child

as for the <html>, need the locale <html> since it can have a lang prop with the actual locale, unlike the root <html> for which locale is undefined

The first error is no more
![chrome_mwRWYxaVo3](https://github.com/Maakaf/maakaf-website/assets/90090260/58ff6e58-9cfd-4c09-b0e9-d9a6de5405c8)
