### PR TITLE
Direction based on language (ltr, rtl)

### DIFF
--- a/app/[locale]/globals.css
+++ b/app/[locale]/globals.css
@@ -2,6 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+:where(:lang(he)) {
+  direction: rtl;
+}
+:where(:lang(en)) {
+  direction: ltr;
+}
 @layer base {
   html {
     -webkit-tap-highlight-color: transparent;

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -9,6 +9,7 @@ import { HOST } from '@/config/consts';
 import { unstable_setRequestLocale } from 'next-intl/server';
 import { NextIntlClientProvider, useMessages } from 'next-intl';
 import { Locale } from '../i18n';
+import useTextDirection from '@/hooks/useTextDirection';
 
 const birzia = Birzia({
   src: [
@@ -66,10 +67,7 @@ export default function RootLayout({
   unstable_setRequestLocale(locale);
   const messages = useMessages();
 
-  let dir = 'ltr';
-  if (locale === 'he') {
-    dir = 'rtl';
-  }
+  const dir = useTextDirection();
   return (
     <html lang={locale} dir={dir} suppressHydrationWarning={true}>
       <meta charSet="ISO-8859-1" />

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -8,6 +8,7 @@ import Footer from '@/components/Footer/Footer';
 import { HOST } from '@/config/consts';
 import { unstable_setRequestLocale } from 'next-intl/server';
 import { NextIntlClientProvider, useMessages } from 'next-intl';
+import { Locale } from '../i18n';
 
 const birzia = Birzia({
   src: [
@@ -60,13 +61,17 @@ export default function RootLayout({
   params: { locale },
 }: {
   children: React.ReactNode;
-  params: { locale: string };
+  params: { locale: Locale };
 }) {
   unstable_setRequestLocale(locale);
   const messages = useMessages();
 
+  let dir = 'ltr';
+  if (locale === 'he') {
+    dir = 'rtl';
+  }
   return (
-    <html lang={locale} dir="rtl" suppressHydrationWarning={true}>
+    <html lang={locale} dir={dir} suppressHydrationWarning={true}>
       <meta charSet="ISO-8859-1" />
 
       <body

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,7 +8,7 @@ export default function RootLayout({
   params: { locale: string };
 }) {
   return (
-    <html lang={locale} dir="rtl">
+    <html lang={locale}>
       <body>{children}</body>
     </html>
   );


### PR DESCRIPTION
[Define direction based on language directly in css](https://github.com/Maakaf/maakaf-website/commit/e27c7ea590cd6942dfc65f09931faf2465b8b2ba)
Uses :where selector so this direction has lower specificity than a class

[Accessible dir prop based on language in the <html>](https://github.com/Maakaf/maakaf-website/commit/e90baf2a5706f45a9d68d8672cc716309986f0ce)

'en' to the left with ltr, 'he' to the right with rtl
![chrome_RNPimFuFdK](https://github.com/Maakaf/maakaf-website/assets/90090260/a50516ce-2d7f-43ae-b69f-92879211d147)
